### PR TITLE
Set spawn timeout to 5 min instead of 300 ms

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ module.exports.install = function(specPath) {
               var cp = spawn(npmCommand, npmArgs, {
                 cwd: packagePath,
                 stdio: 'inherit',
-                timeout: 300
+                timeout: 300000
               })
               return new RSVP.Promise(function(resolve, reject) {
                 cp.on('exit', function(code, signal) {


### PR DESCRIPTION
The timeout option here didn't do anything on node 6.17.1 because this option was introduced in node v14.18.0 and it's in milliseconds, not seconds. See https://nodejs.org/api/child_process.html#child_processspawncommand-args-options